### PR TITLE
fix(mono-provider.tsx): set mono ref obj to useRef

### DIFF
--- a/mono-provider.tsx
+++ b/mono-provider.tsx
@@ -13,7 +13,7 @@ export const MonoContext = React.createContext<MonoContextType>({
 })
 
 function MonoProvider(props: any): JSX.Element {
-  const ref = React.createRef<MonoConnectRefObj>()
+  const ref = React.useRef<MonoConnectRefObj>()
 
   function init() {
     ref.current?.openWidget();


### PR DESCRIPTION
Hello Mono Team, I was integrating Mono and hit a snag, I noticed that when I call the init function, nothing actually happens, I went into your provider's code and realised that the `createRef` was being to create a reference to the MonoConnect component, this I assumed is supposed to work but it didn't, it seems createRef will always create a new reference, this possibly causes the current ref to be null when called even after being set, but as a solution changing that to `useRef` made it work. #6 