### PR TITLE
Deprecate `reauth_token` in favor of `account`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ web-build/
 examples/node_modules
 examples/.expo
 examples/.expo-shared
+.idea
 
 # macOS
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Thanks for contributing to Mono Connect React Native SDK!
 
 ## Issues
 
-The Mono Connect React Native SDK makes it quick and easy to onboard users to Mono in your iOS app. We provide a out-of-the-box way to connect your users' financial details.
+The Mono Connect React Native SDK makes it quick and easy to onboard users to Mono in your React Native app. We provide a out-of-the-box way to connect your users' financial details.
 
-If you're having general trouble with Mono Connect React Native SDK or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+If you're having general trouble with Mono Connect React Native SDK or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 If you've found a bug in Mono Connect React Native SDK, please [let us know](https://github.com/withmono/connect-react-native/issues/new)! You may
 also want to check out our [issue template](https://github.com/withmono/conncet-react-native/tree/develop/.github/ISSUE_TEMPLATE.md).

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ function LinkAccount() {
   )
 }
 
-function ReauthoriseUserAccount({reauth_token}) {
+function ReauthoriseUserAccount({accountId}) {
   const { reauthorise } = useMonoConnect()
 
   return (
     <View style={{marginBottom: 10}}>
-      <TouchableOpacity onPress={() => reauthorise(reauth_token)}>
+      <TouchableOpacity onPress={() => reauthorise(accountId)}>
         <Text style={{color: 'blue'}}>Reauthorise user account</Text>
       </TouchableOpacity>
     </View>
@@ -97,7 +97,7 @@ function InitiateDirectDebit() {
 }
 
 export default function App() {
-  const reauth_token = "code_xyz";
+  const accountId = "account_xyz";
   const payConfig = {
     scope: "payments",
     data: {
@@ -114,7 +114,7 @@ export default function App() {
           <InitiateDirectDebit />
         </MonoProvider>
 
-        <ReauthoriseUserAccount reauth_token={reauth_token} />
+        <ReauthoriseUserAccount accountId={accountId} />
       </View>
     </MonoProvider>
   );
@@ -151,11 +151,28 @@ export default function App() {
     <MonoProvider {...config}>
       <View style={styles.container}>        
         <MonoConnectButton />
-        <MonoConnectButton reauth_token="code_xyz" /> // for reauthorisation with MonoConnectButton
+        <MonoConnectButton accountId="account_xyz" /> // for reauthorisation with MonoConnectButton
       </View>
     </MonoProvider>
   );
 }
+```
+
+### Re-authorizing an Account with Mono
+#### Fetching Account ID for previously linked account
+
+You can fetch the Account ID of a linked account from the [Mono dashboard](https://app.mono.co/customers).
+
+Alternatively, make an API call to the [Exchange Token Endpoint](https://api.withmono.com/v2/accounts/auth) with the code from a successful linking and your mono application secret key. If successful, this will return an Account ID.
+
+##### Sample request:
+```shell
+curl --request POST \
+  --url https://api.withmono.com/v2/accounts/auth \
+  --header 'Content-Type: application/json' \
+  --header 'accept: application/json' \
+  --header 'mono-sec-key: your_secret_key' \
+  --data '{"code":"string"}'
 ```
 
 ## Configuration Options
@@ -178,7 +195,7 @@ This is your Mono public API key from the [Mono dashboard](https://app.withmono.
 ### <a name="scope"></a> `scope`
 **String: Required**
 
-This is the scope the widget will launch with. This can either be `auth` or `payments`
+This is the scope the widget will launch with. This can be `auth`, `reauth`, or `payments`
 
 ### <a name="customer"></a> `Customer`
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ The Mono Connect SDK is a quick and secure way to link bank accounts to Mono fro
 
 For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, TransferPay) use the server-side [Mono API](https://docs.mono.co/docs/intro-to-mono-api).
 
-## Version 2 Public Beta
-<b>Important</b>: Version 2 is currently in the public beta phase. This means it's available for testing and feedback from the community. Please be aware that there may be bugs, and some features might undergo changes before the stable release.
-
 ## Documentation
 
 For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/intro-to-mono-connect-widget).
@@ -30,6 +27,16 @@ Using yarn
 yarn add @mono.co/connect-react-native
 ```
 Also install ```react-native-webview``` because it's a peer dependency for this package.
+
+## Additional Setup
+### Android
+
+State the camera permission in your `android/app/src/main/AndroidManifest.xml` file.
+
+```xml
+<uses-permission android:name="android.permission.CAMERA"/>
+```
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For complete information about Mono Connect, head to the [docs](https://docs.mon
 ## Getting Started
 
 1. Register on the [Mono](https://app.mono.com) website and get your public and secret keys.
-2. Setup a server to [exchange tokens](https://docs.mono.co/api/bank-data/authorisation/exchange-token) to access user financial data with your Mono secret key.
+2. Set up a server to [exchange tokens](https://docs.mono.co/api/bank-data/authorisation/exchange-token) to access user financial data with your Mono secret key.
 
 ## Installation
 Using NPM
@@ -168,7 +168,7 @@ export default function App() {
 ### Re-authorizing an Account with Mono
 #### Fetching Account ID for previously linked account
 
-You can fetch the Account ID of a linked account from the [Mono dashboard](https://app.mono.co/customers).
+You can fetch the Account ID of a linked account from the [Mono dashboard](https://app.mono.co/customers) or [API](https://docs.mono.co/docs/customers).
 
 Alternatively, make an API call to the [Exchange Token Endpoint](https://api.withmono.com/v2/accounts/auth) with the code from a successful linking and your mono application secret key. If successful, this will return an Account ID.
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 The Mono Connect SDK is a quick and secure way to link bank accounts to Mono from within your React Native app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app (credential validation, multi-factor authentication, error handling, etc).
 
-For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, TransferPay) use the server-side [Mono API](https://docs.mono.co/docs/intro-to-mono-api).
+For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, TransferPay) use the server-side [Mono API](https://docs.mono.co/api).
 
 ## Documentation
 
-For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/intro-to-mono-connect-widget).
+For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/financial-data/overview).
 
 
 ## Getting Started
 
-1. Register on the [Mono](https://app.withmono.com/dashboard) website and get your public and secret keys.
-2. Setup a server to [exchange tokens](https://docs.mono.co/reference/authentication-endpoint) to access user financial data with your Mono secret key.
+1. Register on the [Mono](https://app.mono.com) website and get your public and secret keys.
+2. Setup a server to [exchange tokens](https://docs.mono.co/api/bank-data/authorisation/exchange-token) to access user financial data with your Mono secret key.
 
 ## Installation
 Using NPM

--- a/examples/App.js
+++ b/examples/App.js
@@ -42,7 +42,7 @@ export default function App() {
 
         <LinkAccount />
 
-        <MonoConnectButton />
+        <MonoConnectButton accountId="65bb8ab6ed5e47f3015254f6" />
       </View>
     </MonoProvider>
   );

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@mono.co/connect-react-native": "^2.0.5",
+    "@mono.co/connect-react-native": "^2.1.0",
     "expo": "^42.0.0",
     "expo-status-bar": "~1.0.4",
     "react": "16.13.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@mono.co/connect-react-native": "^0.1.0",
+    "@mono.co/connect-react-native": "^2.0.5",
     "expo": "^42.0.0",
     "expo-status-bar": "~1.0.4",
     "react": "16.13.1",

--- a/mono-connect-button.tsx
+++ b/mono-connect-button.tsx
@@ -12,12 +12,12 @@ import { MonoConnectButtonProps } from './types';
 import useMonoConnect from './use-mono-connect';
 
 const MonoConnectButton: React.FC<MonoConnectButtonProps> = (props) => {
-  const { reauth_token } = props;
+  const { accountId } = props;
   const { init, reauthorise, scope } = useMonoConnect()
   let Btn: React.ComponentType<any>;
 
   function onPress() {
-    if(reauth_token) return reauthorise(reauth_token);
+    if(accountId) return reauthorise(accountId);
 
     init();
   }

--- a/mono-connect.tsx
+++ b/mono-connect.tsx
@@ -9,15 +9,15 @@ const MonoConnect: React.FC<MonoConnectProps> = (props) => {
   const connect_url = React.useMemo(() => {
     const qs: any = {
       key: publicKey,
-      code: otherConfig.reauth_token,
-      scope: otherConfig?.scope,
-      data: otherConfig?.data,
-      reference: otherConfig?.reference,
+      account: otherConfig.accountId,
+      scope: otherConfig.scope,
+      data: otherConfig.data,
+      reference: otherConfig.reference,
       version: '2023-12-14',
       ...otherConfig
     };
     return createUrl(qs);
-  }, [otherConfig.reauth_token, publicKey, otherConfig.reference])
+  }, [otherConfig.accountId, publicKey, otherConfig.reference]);
 
   function handleMessage(message: string) {
     const { setOpenWidget } = otherConfig;

--- a/mono-connect.tsx
+++ b/mono-connect.tsx
@@ -9,10 +9,12 @@ const MonoConnect: React.FC<MonoConnectProps> = (props) => {
   const connect_url = React.useMemo(() => {
     const qs: any = {
       key: publicKey,
-      account: otherConfig.accountId,
-      scope: otherConfig.scope,
-      data: otherConfig.data,
-      reference: otherConfig.reference,
+      scope: otherConfig?.scope,
+      data: {
+        ...(otherConfig?.data || {}),
+        ...(otherConfig?.accountId && { account: otherConfig.accountId }),
+      },
+      reference: otherConfig?.reference,
       version: '2023-12-14',
       ...otherConfig
     };

--- a/mono-connect.tsx
+++ b/mono-connect.tsx
@@ -5,24 +5,33 @@ import { MonoConnectProps, WebviewMessage, MonoEventData } from './types';
 import { createUrl } from './utils';
 
 const MonoConnect: React.FC<MonoConnectProps> = (props) => {
-  const { publicKey, onClose, onSuccess, onEvent, openWidget, children, ...otherConfig } = props;
+  const {
+      publicKey,
+      onClose,
+      onSuccess,
+      onEvent,
+      openWidget,
+      setOpenWidget,
+      accountId,
+      children,
+      ...otherConfig
+  } = props;
   const connect_url = React.useMemo(() => {
     const qs: any = {
       key: publicKey,
       scope: otherConfig?.scope,
       data: {
         ...(otherConfig?.data || {}),
-        ...(otherConfig?.accountId && { account: otherConfig.accountId }),
+        ...(accountId && { account: accountId }),
       },
       reference: otherConfig?.reference,
       version: '2023-12-14',
       ...otherConfig
     };
     return createUrl(qs);
-  }, [otherConfig.accountId, publicKey, otherConfig.reference]);
+  }, [accountId, publicKey, otherConfig.reference]);
 
   function handleMessage(message: string) {
-    const { setOpenWidget } = otherConfig;
     const response: WebviewMessage = JSON.parse(message);
 
     const eventData: MonoEventData = response.data;
@@ -72,8 +81,6 @@ const MonoConnect: React.FC<MonoConnectProps> = (props) => {
   }
 
   function RenderError({ name }: any) {
-    const { setOpenWidget } = otherConfig;
-
     return (
       <View style={styles.errorScreen}>
         <Text style={styles.errorMessage}>

--- a/mono-provider.tsx
+++ b/mono-provider.tsx
@@ -2,28 +2,30 @@ import React from 'react';
 import MonoConnect from './mono-connect';
 import { MonoProviderProps } from './types';
 
+const REAUTH_SCOPE = 'reauth';
+
 export interface MonoContextType {
   init: () => void
-  reauthorise: (reauth_code: string) => void;
+  reauthorise: (accountId: string) => void;
   scope?: string;
 }
 
 export const MonoContext = React.createContext<MonoContextType>({
   init: () => null,
   reauthorise: () => null,
-})
+});
 
 function MonoProvider(props: MonoProviderProps) {
   const [openWidget, setOpenWidget] = React.useState<boolean>(false);
-  const [reauthToken, setReauthToken] = React.useState<any>(null);
+  const [accountId, setAccountId] = React.useState<string | null>(null);
 
   function init() {
-    setReauthToken(null);
+    setAccountId(null);
     setOpenWidget(true);
   }
 
-  function reauthorise(reauth_token: string) {
-    setReauthToken(reauth_token);
+  function reauthorise(accountId: string) {
+    setAccountId(accountId);
     setOpenWidget(true);
   }
 
@@ -31,18 +33,18 @@ function MonoProvider(props: MonoProviderProps) {
     openWidget,
     setOpenWidget,
     ...props
-  }
+  };
 
-  if (reauthToken){
-    payload['reauth_token'] = reauthToken
+  if (accountId) {
+    payload['accountId'] = accountId;
   }
 
   return (
-    <MonoContext.Provider value={{init, reauthorise, scope: props?.scope}}>
+    <MonoContext.Provider value={{init, reauthorise, scope: accountId ? REAUTH_SCOPE : props?.scope}}>
       <MonoConnect {...payload} />
       {props.children}
     </MonoContext.Provider>
   )
 }
 
-export default MonoProvider
+export default MonoProvider;

--- a/mono-provider.tsx
+++ b/mono-provider.tsx
@@ -37,7 +37,7 @@ function MonoProvider(props: MonoProviderProps) {
 
   if (accountId) {
     payload['accountId'] = accountId;
-    payload.scope = REAUTH_SCOPE;
+    payload.scope = props?.scope ?? REAUTH_SCOPE;
   }
 
   return (

--- a/mono-provider.tsx
+++ b/mono-provider.tsx
@@ -37,10 +37,11 @@ function MonoProvider(props: MonoProviderProps) {
 
   if (accountId) {
     payload['accountId'] = accountId;
+    payload.scope = REAUTH_SCOPE;
   }
 
   return (
-    <MonoContext.Provider value={{init, reauthorise, scope: accountId ? REAUTH_SCOPE : props?.scope}}>
+    <MonoContext.Provider value={{init, reauthorise, scope: payload.scope}}>
       <MonoConnect {...payload} />
       {props.children}
     </MonoContext.Provider>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mono.co/connect-react-native",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Easily add mono connect widget to your react-native app and get access to users' financial data.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mono.co/connect-react-native",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Easily add mono connect widget to your react-native app and get access to users' financial data.",
   "main": "lib/index.js",
   "directories": {

--- a/types.ts
+++ b/types.ts
@@ -1,19 +1,12 @@
 import { ReactNode } from "react";
 
-type Nullable<T> = T | null;
-
 interface WebviewMessage {
   type: string;
   data: any;
 }
 
-interface MonoConnectRefObj {
-  openWidget: () => void;
-  reauthorise: (reauth_code: string) => void;
-}
-
 interface MonoConnectButtonProps {
-  reauth_token?: string;
+  accountId?: string;
 }
 
 interface MonoProviderProps extends DataConfig {
@@ -21,7 +14,7 @@ interface MonoProviderProps extends DataConfig {
   publicKey: string;
   onClose: () => void;
   onSuccess: (data: {id: string}) => void;
-  reauth_token?: string;
+  accountId?: string;
   onEvent?: (eventName: string, data: MonoEventData) => void;
   reference?: string;
 }
@@ -69,7 +62,7 @@ interface MonoConnectProps extends DataConfig {
   onClose: () => void;
   onSuccess: (data: {id: string}) => void;
   live?: boolean; // default is true
-  reauth_token?: string;
+  accountId?: string;
   setOpenWidget: (v: boolean) => void;
   openWidget: boolean;
   onEvent?: (eventName: string, data: MonoEventData) => void;
@@ -80,7 +73,6 @@ interface MonoConnectProps extends DataConfig {
 export {
   WebviewMessage,
   MonoConnectProps,
-  MonoConnectRefObj,
   MonoConnectButtonProps,
   MonoProviderProps,
   DataConfig,

--- a/utils.ts
+++ b/utils.ts
@@ -25,7 +25,7 @@ function validate(config: any) {
 }
 
 function validatePaymentsData(data: any) {
-  data = {payment_id: undefined,...data};
+  data = {payment_id: undefined, ...data};
   const requiredFields = ["payment_id"];
   for(let param in data) {
     if(requiredFields.includes(param)) {


### PR DESCRIPTION
This PR replaces `reauth_token` with `account` for account re-authorisation. The `account` field takes the Account ID of a previously linked account and passes that to the Connect Widget which then handles re-authorisation. This eliminates the need for partners to make an extra call to the [reauthorise endpoint](https://docs.mono.co/api/bank-data/reauth) for a `reauth_token`.



https://github.com/user-attachments/assets/1616ee49-21b2-4f34-affa-cfeb66798fa4

